### PR TITLE
Add support for Razer Cobra Pro Wired and Wireless 2.4GHz mouse

### DIFF
--- a/src/devices/cobra_pro_wired.json
+++ b/src/devices/cobra_pro_wired.json
@@ -1,0 +1,15 @@
+{
+  "name": "Razer Cobra Pro Wired",
+  "productId": "0x00AF",
+  "mainType": "mouse",
+  "image": "https://dl.razerzone.com/src2/13182/13182-1-en-v2.png",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects", "reactive", "breathe"],
+  "featuresConfig": [
+    {
+      "dpi": {
+        "max": 30000
+      }
+    }
+  ]
+}

--- a/src/devices/cobra_pro_wireless.json
+++ b/src/devices/cobra_pro_wireless.json
@@ -1,0 +1,22 @@
+{
+  "name": "Razer Cobra Pro Wireless",
+  "productId": "0x00B0",
+  "mainType": "mouse",
+  "image": "https://dl.razerzone.com/src2/13182/13182-1-en-v2.png",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects", "reactive", "breathe"],
+  "featuresConfig": [
+    {
+      "mouseBrightness": {
+        "enabledMatrix": false,
+        "enabledLeft": false,
+        "enabledRight": false
+      }
+    },
+    {
+      "dpi": {
+        "max": 30000
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds support for the Razer Cobra Pro mouse that is supported in [openrazer](https://github.com/openrazer/openrazer) in [wirless 2.4GHz](https://github.com/openrazer/openrazer/issues/2105) and [wired](https://github.com/openrazer/openrazer/issues/2179) configurations

* compiles and installs after using `yarn dist`
* tested manually using my Razer Cobra Pro device in wired and wireless (2.4GHz) configuration  on a MacBook Air 2024 with macOS 14.5
* Needs Cobra Pro support added to libracermacos in [this PR](https://github.com/stickoking/librazermacos/pull/9)

* Broadly it seems to work. Some functionally may be improvable. I lack deeper insight into Razer mouse features and would welcome suggestions for improvement.   