### PR TITLE
Add support for Firefly V2 Pro & Charging Pad Chroma, and fix Basilisk V3 Pro

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "librazermacos"]
 	path = librazermacos
-	url = https://github.com/stickoking/librazermacos
+	url = https://github.com/Logan-Harris24/librazermacos
 [submodule "iohook"]
 	path = iohook
 	url = https://github.com/overcurrent/iohook

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Accessories:
 
 - Razer Mouse Bungee V3 Chroma
 - Razer Mouse Charging Dock
+- Razer Mouse Dock Pro
 - Razer Thunderbolt 4 Dock Chroma
 
 Please feel free to open pull requests for new devices you have tested.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razer-macos",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Open source color effects manager for Razer peripherals on macOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "razer-macos",
-  "version": "0.4.15",
-  "description": "Open source color effects manager for Razer peripherals on macOS",
+  "version": "0.4.16",
+  "description": "Open source color effects manager for Razer peripherals on MacOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razer-macos",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Open source color effects manager for Razer peripherals on MacOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razer-macos",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "Open source color effects manager for Razer peripherals on MacOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razer-macos",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Open source color effects manager for Razer peripherals on MacOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razer-macos",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Open source color effects manager for Razer peripherals on MacOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razer-macos",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Open source color effects manager for Razer peripherals on MacOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razer-macos",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "description": "Open source color effects manager for Razer peripherals on MacOS",
   "license": "GPL-2.0-only",
   "main": "src/main/index.js",

--- a/src/devices/basilisk_v2.json
+++ b/src/devices/basilisk_v2.json
@@ -2,7 +2,7 @@
   "name": "Razer Basilisk V2",
   "productId": "0x0085",
   "mainType": "mouse",
-  "image": "https://assets3.razerzone.com/XianHhS4aWPIr4UJLTatssIfkZI=/300x300/https%3A%2F%2Fhybrismediaprod.blob.core.windows.net%2Fsys-master-phoenix-images-container%2Fha0%2Fhb6%2F9529652445214%2Fbasilisk-v3-pro-black-2-500x500.png",
+  "image": "https://assets.razerzone.com/eeimages/support/products/1617/1617_basilisk-v2.png",
   "features": null,
   "featuresMissing": ["waveSimple"],
   "featuresConfig": [

--- a/src/devices/basilisk_v2.json
+++ b/src/devices/basilisk_v2.json
@@ -2,7 +2,7 @@
   "name": "Razer Basilisk V2",
   "productId": "0x0085",
   "mainType": "mouse",
-  "image": "https://assets.razerzone.com/eeimages/support/products/1617/1617_basilisk-v2.png",
+  "image": "https://assets3.razerzone.com/XianHhS4aWPIr4UJLTatssIfkZI=/300x300/https%3A%2F%2Fhybrismediaprod.blob.core.windows.net%2Fsys-master-phoenix-images-container%2Fha0%2Fhb6%2F9529652445214%2Fbasilisk-v3-pro-black-2-500x500.png",
   "features": null,
   "featuresMissing": ["waveSimple"],
   "featuresConfig": [

--- a/src/devices/basilisk_v3_pro_wired.json
+++ b/src/devices/basilisk_v3_pro_wired.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Basilisk V3",
+  "productId": "0x00aa",
+  "mainType": "mouse",
+  "image": "https://m.media-amazon.com/images/I/71L-flqtTwL.__AC_SX300_SY300_QL70_FMwebp_.jpg",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects", "reactive", "breathe"],
+  "featuresConfig": [
+    {
+      "dpi": {
+        "max": 30000
+      }
+    },
+    {
+      "mouseBrightness": {
+        "enabledLeft": false,
+        "enabledRight": false
+      }
+    }
+  ]
+}

--- a/src/devices/basilisk_v3_pro_wireless.json
+++ b/src/devices/basilisk_v3_pro_wireless.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Basilisk V3",
+  "productId": "0x00ab",
+  "mainType": "mouse",
+  "image": "https://m.media-amazon.com/images/I/71L-flqtTwL.__AC_SX300_SY300_QL70_FMwebp_.jpg",
+  "features": null,
+  "featuresMissing": ["oldMouseEffects", "reactive", "breathe"],
+  "featuresConfig": [
+    {
+      "dpi": {
+        "max": 30000
+      }
+    },
+    {
+      "mouseBrightness": {
+        "enabledLeft": false,
+        "enabledRight": false
+      }
+    }
+  ]
+}

--- a/src/devices/charging_pad_chroma.json
+++ b/src/devices/charging_pad_chroma.json
@@ -1,0 +1,7 @@
+{
+  "name": "Razer Charging Pad Chroma",
+  "productId": "0x0F26",
+  "mainType": "accessory",
+  "image": "https://dl.razerzone.com/Images/ChargingPadChroma/CPC-ProductImage.png",
+  "features": null
+}

--- a/src/devices/deathstalker_v2_pro.json
+++ b/src/devices/deathstalker_v2_pro.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Deathstalker V2 Pro",
+  "productId": "0x0292",
+  "mainType": "keyboard",
+  "image": "https://assets2.razerzone.com/images/pnx.assets/a54bdf79abdfc0d42a0fff19047725a3/deathstalker-v2_500x500.png",
+  "features": null,
+  "featuresConfig": [
+    {
+      "ripple": {
+        "rows": 6,
+        "cols": 22
+      }
+    },
+    {
+      "wheel": {
+        "rows": 6,
+        "cols": 22
+      }
+    }
+  ]
+}

--- a/src/devices/firefly_v2_pro.json
+++ b/src/devices/firefly_v2_pro.json
@@ -1,0 +1,7 @@
+{
+  "name": "Razer Firefly V2 Pro",
+  "productId": "0x0c08",
+  "mainType": "mousemat",
+  "image": "https://assets3.razerzone.com/j_4_V23s9IFZcA3PJrJP6IHAzgs=/300x300/https%3A%2F%2Fhybrismediaprod.blob.core.windows.net%2Fsys-master-phoenix-images-container%2Fh7e%2Fh48%2F9763779444766%2Ffirefly-v2-pro-black-2-500x500.png",
+  "features": null
+}

--- a/src/devices/goliathus_chroma_3XL.json
+++ b/src/devices/goliathus_chroma_3XL.json
@@ -1,0 +1,8 @@
+{
+  "name": "Razer Goliathus Chroma 3XL",
+  "productId": "0x0C06",
+  "mainType": "mousemat",
+  "image": "https://m.media-amazon.com/images/I/71kNXyFfspL.__AC_SX300_SY300_QL70_FMwebp_.jpg",
+  "features": null,
+  "featuresMissing": ["waveSimple"]
+}

--- a/src/devices/mouse_dock_pro.json
+++ b/src/devices/mouse_dock_pro.json
@@ -1,0 +1,7 @@
+{
+  "name": "Razer Mouse Dock Pro",
+  "productId": "0x00A4",
+  "mainType": "accessory",
+  "image": "https://assets2.razerzone.com/images/pnx.assets/c547009c7f47ab631871b6c23716db93/razer-mouse-dock-pro-ogimage-1200x630-v2.jpg",
+  "features": null
+}

--- a/src/devices/ornata_v3.json
+++ b/src/devices/ornata_v3.json
@@ -1,0 +1,21 @@
+{
+  "name": "Razer Ornata V3",
+  "productId": "0x02a1",
+  "mainType": "keyboard",
+  "image": "https://assets3.razerzone.com/JCRG_e1sCkQ15E6iooW22TlqP0o=/300x300/https%3A%2F%2Fmedias-p1.phoenix.razer.com%2Fsys-master-phoenix-images-container%2Fhfd%2Fh73%2F9533910810654%2Fornata-v3-4-500x500.png",
+  "features": null,
+  "featuresConfig": [
+    {
+      "ripple": {
+          "rows": 6,
+          "cols": 22
+      }
+    },
+    {
+      "wheel": {
+          "rows": 6,
+          "cols": 22
+      }
+    }
+  ]
+}

--- a/src/main/device/razerdeviceaccessory.js
+++ b/src/main/device/razerdeviceaccessory.js
@@ -5,6 +5,24 @@ export class RazerDeviceAccessory extends RazerDevice {
     super(addon, settingsManager, stateManager, razerProperties);
   }
 
+  async init() {
+    this.brightness = this.addon.accessoryGetBrightness(this.internalId);
+    return super.init();
+  }
+
+  getState() {
+    const deviceState = super.getState();
+    deviceState['brightness'] = this.brightness;
+    return deviceState;
+  }
+
+  resetToState(state) {
+    super.resetToState(state);
+    if(typeof state.brightness !== 'undefined') {
+      this.setBrightness(state.brightness);
+    }
+  }
+
   setModeNone() {
     super.setModeNone();
     this.addon.accessorySetModeNone(this.internalId);
@@ -33,5 +51,14 @@ export class RazerDeviceAccessory extends RazerDevice {
   setWaveExtended(directionSpeed) {
     this.setModeState('waveExtended', directionSpeed);
     this.addon.accessorySetModeWave(this.internalId, directionSpeed);
+  }
+
+  getBrightness() {
+    return this.brightness;
+  }
+
+  setBrightness(brightness) {
+    this.brightness = brightness;
+    this.addon.accessorySetBrightness(this.internalId, brightness);
   }
 }

--- a/src/main/feature/featurehelper.js
+++ b/src/main/feature/featurehelper.js
@@ -112,6 +112,7 @@ export class FeatureHelper {
           new FeatureWaveExtended(),
           new FeatureSpectrum(),
           new FeatureBreathe(),
+          new FeatureBrightness(),
         ];
       default:
         console.warn("Unknown mainType "+mainType+". Can't detect feature set.");

--- a/src/main/menu/menubuilderdevice.js
+++ b/src/main/menu/menubuilderdevice.js
@@ -122,6 +122,24 @@ function getFeatureBrightness(application, device, feature) {
         },
       },
       {
+        label: 'Set to 25%',
+        click() {
+          updateBrightness(25);
+        },
+      },
+      {
+        label: 'Set to 50%',
+        click() {
+          updateBrightness(50);
+        },
+      },
+      {
+        label: 'Set to 75%',
+        click() {
+          updateBrightness(75);
+        },
+      },
+      {
         label: 'Set to 100%',
         click() {
           updateBrightness(100);

--- a/src/renderer/sections/sectionsettingbrightness.jsx
+++ b/src/renderer/sections/sectionsettingbrightness.jsx
@@ -16,7 +16,11 @@ export class SectionSettingBrightness extends SectionSettingBlock {
     if (this.brightnessFeature) {
       if (this.deviceSelected.mainType === "mousemat") {
         return 'MouseMat Brightness';
-      } else {
+      }
+      else if (this.deviceSelected.mainType === "accessory") {
+        return 'Accessory Brightness'
+      }
+      else {
         return 'Keyboard Brightness';
       }
     }


### PR DESCRIPTION
As the title states, this PR:

- Adds support for 2 new devices (Firefly V2 Pro & Charging Pad Chroma)
- Fixes broken support for Basilisk V3 Pro (Wired & Wireless)
  - Support was added in `librazermacos` but accompanying device json was never added to `razer-macos`

Dependent on accompanying PR:
- [librazermacos PR #11](https://github.com/stickoking/librazermacos/pull/11)
